### PR TITLE
Allow IntoIterators that are not Copy

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,28 +130,16 @@ use doc_comment::doctest;
 doctest!("../Readme.md");
 
 // Check that the type of the expression passed here implements IntoIterator.
-// Hopefully this optimizes away in release builds.
 #[doc(hidden)]
-#[macro_export]
-macro_rules! assert_impl_into_iter {
-    ($x: expr) => {
-        let _ = || {
-            fn assert_impl_into_iter<T>(_: T)
-            where
-                T: IntoIterator,
-            {
-            }
-            assert_impl_into_iter($x);
-        };
-    };
-}
+#[inline(always)]
+pub fn assert_impl_into_iter<T: IntoIterator>(_: &T) {}
 
 /// A Python-like lazy generator-expression
 ///
 /// For details see [module level documentation][super]
 ///
 /// [super]: ../py_comp/index.html
-#[macro_export(local_inner_macros)]
+#[macro_export]
 macro_rules! comp {
     (
         $item_expr: expr;
@@ -159,7 +147,7 @@ macro_rules! comp {
         if $condition: expr $(;)?
     ) => {{
         let into_iterator = $into_iterator;
-        $crate::assert_impl_into_iter!(into_iterator);
+        $crate::assert_impl_into_iter(&into_iterator);
         into_iterator
             .into_iter()
             .filter_map(move |$pattern|
@@ -176,7 +164,7 @@ macro_rules! comp {
         for $pattern: pat in $into_iterator: expr $(;)?
     ) => {{
         let into_iterator = $into_iterator;
-        $crate::assert_impl_into_iter!(into_iterator);
+        $crate::assert_impl_into_iter(&into_iterator);
         into_iterator
             .into_iter()
             .map(move |$pattern| $item_expr)
@@ -189,7 +177,7 @@ macro_rules! comp {
         for $($rest: tt)*
     ) => {{
         let into_iterator = $into_iterator;
-        $crate::assert_impl_into_iter!(into_iterator);
+        $crate::assert_impl_into_iter(&into_iterator);
         into_iterator
             .into_iter()
             .filter_map(move |$pattern|
@@ -208,7 +196,7 @@ macro_rules! comp {
         for $($rest: tt)*
     ) => {{
         let into_iterator = $into_iterator;
-        $crate::assert_impl_into_iter!(into_iterator);
+        $crate::assert_impl_into_iter(&into_iterator);
         into_iterator
             .into_iter()
             .flat_map(move |$pattern|

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,7 +132,7 @@ doctest!("../Readme.md");
 // Check that the type of the expression passed here implements IntoIterator.
 #[doc(hidden)]
 #[inline(always)]
-pub fn assert_impl_into_iter<T: IntoIterator>(_: &T) {}
+pub fn __py_comp_assert_impl_into_iter<T: IntoIterator>(_: &T) {}
 
 /// A Python-like lazy generator-expression
 ///
@@ -147,7 +147,7 @@ macro_rules! comp {
         if $condition: expr $(;)?
     ) => {{
         let into_iterator = $into_iterator;
-        $crate::assert_impl_into_iter(&into_iterator);
+        $crate::__py_comp_assert_impl_into_iter(&into_iterator);
         into_iterator
             .into_iter()
             .filter_map(move |$pattern|
@@ -164,7 +164,7 @@ macro_rules! comp {
         for $pattern: pat in $into_iterator: expr $(;)?
     ) => {{
         let into_iterator = $into_iterator;
-        $crate::assert_impl_into_iter(&into_iterator);
+        $crate::__py_comp_assert_impl_into_iter(&into_iterator);
         into_iterator
             .into_iter()
             .map(move |$pattern| $item_expr)
@@ -177,7 +177,7 @@ macro_rules! comp {
         for $($rest: tt)*
     ) => {{
         let into_iterator = $into_iterator;
-        $crate::assert_impl_into_iter(&into_iterator);
+        $crate::__py_comp_assert_impl_into_iter(&into_iterator);
         into_iterator
             .into_iter()
             .filter_map(move |$pattern|
@@ -196,7 +196,7 @@ macro_rules! comp {
         for $($rest: tt)*
     ) => {{
         let into_iterator = $into_iterator;
-        $crate::assert_impl_into_iter(&into_iterator);
+        $crate::__py_comp_assert_impl_into_iter(&into_iterator);
         into_iterator
             .into_iter()
             .flat_map(move |$pattern|

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,7 +129,7 @@ use doc_comment::doctest;
 
 doctest!("../Readme.md");
 
-// Check that the type of the expression passed here implements IntoIterator.
+/// Check that the type of the expression passed here implements IntoIterator.
 #[doc(hidden)]
 #[inline(always)]
 pub fn __py_comp_assert_impl_into_iter<T: IntoIterator>(_: &T) {}

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -6,6 +6,18 @@ use py_comp::comp;
 #[derive(Debug, PartialEq, Eq)]
 struct Foo(i32);
 
+/// An Iterator that is not Copy.
+#[derive(Debug)]
+struct UncopyableIterator {}
+
+impl Iterator for UncopyableIterator {
+    type Item = ();
+
+    fn next(&mut self) -> Option<()> {
+        None
+    }
+}
+
 #[test]
 fn basic_implementation_1_layer() {
     // This needs to be a reference to an array because of how the closures
@@ -453,4 +465,9 @@ fn triple_nested_structure() {
     let expected_values = (1..28).map(Foo).collect::<Vec<Foo>>();
 
     assert_eq!(expected_values, nested_objects);
+}
+
+#[test]
+fn uncopyable_iterator() {
+    let _ = comp!(x; for x in UncopyableIterator {});
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -13,7 +13,19 @@ struct UncopyableIterator {}
 impl Iterator for UncopyableIterator {
     type Item = ();
 
-    fn next(&mut self) -> Option<()> {
+    fn next(&mut self) -> Option<Self::Item> {
+        None
+    }
+}
+
+/// An Iterator that is not Copy of Iterators that are not Copy.
+#[derive(Debug)]
+struct UncopyableIteratorOfUncopyableIterators {}
+
+impl Iterator for UncopyableIteratorOfUncopyableIterators {
+    type Item = UncopyableIterator;
+
+    fn next(&mut self) -> Option<Self::Item> {
         None
     }
 }
@@ -470,4 +482,13 @@ fn triple_nested_structure() {
 #[test]
 fn uncopyable_iterator() {
     let _ = comp!(x; for x in UncopyableIterator {});
+}
+
+#[test]
+fn uncopyable_iterator_of_uncopyable_iterators() {
+    let _ = comp!(
+        item;
+        for uncopyable_iterator in UncopyableIteratorOfUncopyableIterators {};
+        for item in uncopyable_iterator;
+    );
 }


### PR DESCRIPTION
Saw your post on Reddit. This looks nice!

~~I haven't written a test to test unsized IntoIterators. Feel free to write one for that as well. The move was the most troubling part for me.~~

(This `assert_impl_into_iter` is basically the same approach in Rust pull 31434, btw.)